### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:18
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install --production
+COPY . .
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@ This project demonstrates a basic blogging platform built with **Express**, **EJ
 Install dependencies with `npm install` and start the server with `npm start`.
 The application listens on port `3000` by default.
 
+## Docker
+
+You can run the project along with a MongoDB instance using Docker Compose.
+
+```bash
+docker-compose up --build
+```
+
+This will start the blog on port `3000` and a MongoDB database stored in the
+`mongo-data` volume.
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+services:
+  mongo:
+    image: mongo:4.4
+    restart: always
+    volumes:
+      - mongo-data:/data/db
+  blog:
+    build: .
+    ports:
+      - "3000:3000"
+    depends_on:
+      - mongo
+    environment:
+      - MONGO_URL=mongodb://mongo:27017/blog
+volumes:
+  mongo-data:

--- a/lib/db.js
+++ b/lib/db.js
@@ -17,4 +17,5 @@ var Comment = new Schema({
 
 mongoose.model('Blog', Blog);
 mongoose.model('Comment', Comment);
-mongoose.connect('mongodb://localhost/blog');
+var mongoUrl = process.env.MONGO_URL || 'mongodb://localhost/blog';
+mongoose.connect(mongoUrl);


### PR DESCRIPTION
## Summary
- add `Dockerfile` and `docker-compose.yml` to run app with MongoDB
- allow MongoDB connection URL override via `MONGO_URL`
- document Docker usage

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684be2532c28832db5853b4fe75bd079